### PR TITLE
Fix build for macOS

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -6,7 +6,7 @@ STATIC_LIBUSEFUL=@LIBUSEFUL_BUNDLED@
 
 
 all: $(OBJ) main.c $(STATIC_LIBUSEFUL)
-	gcc $(FLAGS) -ofileferry $(OBJ) main.c $(STATIC_LIBUSEFUL) $(LIBS)
+	gcc $(FLAGS) -o fileferry $(OBJ) main.c $(STATIC_LIBUSEFUL) $(LIBS)
 
 libUseful-5/libUseful.a:
 	make -C libUseful-5

--- a/filestore_dirlist.c
+++ b/filestore_dirlist.c
@@ -1,6 +1,7 @@
 #include "filestore_dirlist.h"
 #include "commands.h"
 #include <fnmatch.h>
+#include <libgen.h> // basename on macOS and musl
 
 void FileStoreDirListFree(TFileStore *FS, ListNode *Dir)
 {


### PR DESCRIPTION
@ColumPaget This fixes the build, assuming that `libUseful` is installed externally with patches from https://github.com/ColumPaget/libUseful/pull/16 and bundled one is removed before the build.